### PR TITLE
Bug fixes

### DIFF
--- a/SQL/Cohort_Prototype.sql
+++ b/SQL/Cohort_Prototype.sql
@@ -23,13 +23,13 @@ CohortDiagnosis AS (
     SELECT
         co.person_id,
         MIN(co.condition_start_date) AS index_date, -- MIN is used to define the index date as the first diagnosis of MCI, Dementia, or Alzheimer's disease
-        MAX(c.concept_name) AS diagnosis_type -- MAX is used to retain a readable diagnosis label
+        MAX(d.icd_name) AS diagnosis_type -- MAX is used to retain a readable diagnosis label
     FROM condition_occurrence co
-    JOIN concept c
-    ON co.condition_concept_id = c.concept_id
-    WHERE c.concept_name LIKE '%mild cognitive% impairment%' -- OR is used since it can be any of the three
-       OR c.concept_name LIKE '%dementia%'
-       OR c.concept_name LIKE '%alzheimer%'
+    JOIN diagnosis_lookup d
+    ON co.condition_concept_id = d.icd_concept_id
+    WHERE d.icd_name LIKE '%mild cognitive% impairment%' -- OR is used since it can be any of the three
+       OR d.icd_name LIKE '%dementia%'
+       OR d.icd_name LIKE '%alzheimer%'
     GROUP BY co.person_id
 ),
  

--- a/SQL/Outcomes/MMSE.sql
+++ b/SQL/Outcomes/MMSE.sql
@@ -6,4 +6,4 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 4169175 and m.value_as_number is not null
+WHERE ml.scale = 'mmse' and m.value_as_number is not null

--- a/SQL/Outcomes/MMSE_Cutoff.sql
+++ b/SQL/Outcomes/MMSE_Cutoff.sql
@@ -13,4 +13,4 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 4169175 and m.value_as_number is not null
+WHERE ml.scale = 'mmse' and m.value_as_number is not null

--- a/SQL/Outcomes/MOCA.sql
+++ b/SQL/Outcomes/MOCA.sql
@@ -6,4 +6,4 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 44808666 and m.value_as_number is not null
+WHERE ml.scale = 'moca' and m.value_as_number is not null

--- a/SQL/Outcomes/MOCA_Cutoff.sql
+++ b/SQL/Outcomes/MOCA_Cutoff.sql
@@ -13,4 +13,4 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 44808666 and m.value_as_number is not null
+WHERE ml.scale = 'moca' and m.value_as_number is not null

--- a/SQL/Outcomes/Master_Cutoff.sql
+++ b/SQL/Outcomes/Master_Cutoff.sql
@@ -13,7 +13,7 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 37017073 and m.value_as_number is not null
+WHERE ml.scale = 'minicog' and m.value_as_number is not null
 
 UNION
 
@@ -31,7 +31,7 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 4169175 and m.value_as_number is not null
+WHERE ml.scale = 'mmse' and m.value_as_number is not null
 
 UNION 
 
@@ -50,4 +50,4 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 44808666 and m.value_as_number is not null
+WHERE ml.scale = 'moca' and m.value_as_number is not null

--- a/SQL/Outcomes/Master_Percentage.sql
+++ b/SQL/Outcomes/Master_Percentage.sql
@@ -7,7 +7,7 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 44808666 and m.value_as_number is not null
+WHERE ml.scale = 'moca' and m.value_as_number is not null
 
 UNION
 
@@ -19,7 +19,7 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 37017073 and m.value_as_number is not null
+WHERE ml.scale = 'minicog' and m.value_as_number is not null
 
 UNION
 
@@ -31,4 +31,4 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 4169175 and m.value_as_number is not null
+WHERE ml.scale = 'mmse' and m.value_as_number is not null

--- a/SQL/Outcomes/Mini-Cog.sql
+++ b/SQL/Outcomes/Mini-Cog.sql
@@ -6,4 +6,4 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 37017073 and m.value_as_number is not null
+WHERE ml.scale = 'minicog' and m.value_as_number is not null

--- a/SQL/Outcomes/MiniCog_Cutoff.sql
+++ b/SQL/Outcomes/MiniCog_Cutoff.sql
@@ -13,4 +13,4 @@ m.patient_id
 FROM measurement m
 JOIN measurement_lookup ml
 ON m.measurement_concept_id = ml.measurement_concept_id
-WHERE m.measurement_concept_id = 37017073 and m.value_as_number is not null
+WHERE ml.scale = 'minicog' and m.value_as_number is not null

--- a/SQL/Predictors/Labs_Predictors
+++ b/SQL/Predictors/Labs_Predictors
@@ -28,18 +28,14 @@ ranked AS (
             PARTITION BY person_id, measurement_concept_id
             ORDER BY measurement_datetime DESC, measurement_id DESC
         ) AS rn,
-        LAG(value_as_number) OVER ( --gathers previous value before most recent
+        LAG(value_as_number) OVER ( --gathers previous value of the same laboratory
             PARTITION BY person_id, measurement_concept_id
             ORDER BY measurement_datetime ASC, measurement_id ASC
         ) AS previous_score,
-        LAG(measurement_datetime) OVER ( --gathers previous datetime
+        LAG(measurement_datetime) OVER ( --gathers previous datetime of the same laboratory
             PARTITION BY person_id, measurement_concept_id
             ORDER BY measurement_datetime ASC, measurement_id ASC
-        ) AS previous_score_datetime,
-        LAG(measurement_concept_id) OVER ( --gathers previous concept_id
-            PARTITION BY person_id, measurement_concept_id
-            ORDER BY measurement_datetime ASC, measurement_id ASC
-        ) AS previous_score_concept
+        ) AS previous_score_datetime
         
     FROM labs_cohort
 ),
@@ -66,7 +62,6 @@ most_recent AS (
         value_as_number AS most_recent_score,
         previous_score,
         previous_score_datetime,
-        previous_score_concept,
         measurement_datetime
     FROM ranked
     WHERE rn = 1


### PR DESCRIPTION
This pull request updates several SQL queries to improve maintainability and flexibility by replacing hardcoded concept IDs with scale-based lookups, and refines the diagnosis type labeling in cohort selection. The changes make the code more robust to future updates in concept IDs and improve consistency across outcome queries.

**Diagnosis and Labeling Improvements:**

* In `Cohort_Prototype.sql`, the diagnosis type is now sourced from `diagnosis_lookup.icd_name` instead of `concept.concept_name`, and the join/where conditions have been updated accordingly. This makes the diagnosis labeling more consistent and decouples it from the `concept` table.

**Measurement Queries Refactoring:**

* All outcome SQL queries  now use the `ml.scale` field from the `measurement_lookup` table to filter by scale name (e.g., 'mmse', 'moca', 'minicog') instead of hardcoded `measurement_concept_id` values. This improves maintainability and allows for easier updates if concept IDs change. 

**rank grouped by measurement_concept_id**

* In `Labs_Predictors.sql` the CTE ranked now properly preforms the LAG so that it is preformed with the same laboratory in order to properly compare scores of the same type.

These updates collectively ensure that the queries are more resilient to changes in underlying concept IDs and that diagnosis and measurement labels are handled in a more standardized way.