### PR TITLE
Update SQL query prototype to bump cohort size to 29k

### DIFF
--- a/SQL/Cohort_Prototype.sql
+++ b/SQL/Cohort_Prototype.sql
@@ -16,20 +16,35 @@ WITH DrugsUsed AS (
         OR brand_name LIKE '%namenda%'
         OR brand_name LIKE '%belsomra%'
         OR brand_name LIKE '%risperdal%'
+    UNION ALL --- USING THE GENERIC NAME OF THE DRUGS
+    SELECT DISTINCT drug_concept_id
+    FROM drug_lookup
+    WHERE drug_concept_name LIKE '%lecanemab%'
+    OR drug_concept_name LIKE '%donanemab%'
+    OR drug_concept_name LIKE '%brexpiprazole%'
+    OR drug_concept_name LIKE '%memantine%'
+    OR drug_concept_name LIKE '%donepezil%'
+    OR drug_concept_name LIKE '%rivastigmina%'
+    OR drug_concept_name LIKE '%galantamine%'
+    OR drug_concept_name LIKE '%benzgalantamine%'
+    OR drug_concept_name LIKE '%suvorexant%'
+    OR drug_concept_name LIKE '%risperidone%'
 ),
  
 -- First diagnosis date of MCI OR Dementia OR Alzheimer's disease
 CohortDiagnosis AS (
     SELECT
         co.person_id,
-        MIN(co.condition_start_date) AS index_date, -- MIN is used to define the index date as the first diagnosis of MCI, Dementia, or Alzheimer's disease
+        MIN(co.condition_start_date) AS index_date,
+        -- MIN is used to define the index date as the first diagnosis of MCI, Dementia, or Alzheimer's disease
         MAX(d.icd_name) AS diagnosis_type -- MAX is used to retain a readable diagnosis label
     FROM condition_occurrence co
     JOIN diagnosis_lookup d
     ON co.condition_concept_id = d.icd_concept_id
-    WHERE d.icd_name LIKE '%mild cognitive% impairment%' -- OR is used since it can be any of the three
-       OR d.icd_name LIKE '%dementia%'
-       OR d.icd_name LIKE '%alzheimer%'
+    WHERE disorder_group = 'dementia'
+    OR array_contains(keywords, 'mci')
+    OR array_contains(keywords, 'ad')
+    
     GROUP BY co.person_id
 ),
  
@@ -53,13 +68,13 @@ CognitiveScores AS (
         m.value_as_number
     FROM measurement m
     JOIN measurement_lookup ml
-    ON m.custom2_str = ml.custom2_str
+    ON m.measurement_concept_id = ml.measurement_concept_id
     JOIN CohortDiagnosis cd
     ON m.person_id = cd.person_id
     WHERE ml.scale IN ('minicog', 'moca', 'mmse')
-    AND m.value_as_number IS NOT NULL
+    --AND m.value_as_number IS NOT NULL We should handle this by using the measurement_lookup values
     AND m.measurement_date >= cd.index_date -- Ensures a cognitive assessment occurs after cohort entry
-)
+),
  
 -- Final Cohort
 SELECT

--- a/SQL/Cohort_Prototype.sql
+++ b/SQL/Cohort_Prototype.sql
@@ -72,7 +72,7 @@ CognitiveScores AS (
     JOIN CohortDiagnosis cd
     ON m.person_id = cd.person_id
     WHERE ml.scale IN ('minicog', 'moca', 'mmse')
-    --AND m.value_as_number IS NOT NULL We should handle this by using the measurement_lookup values
+    --AND m.value_as_number IS NOT NULL  -- We should handle this case by using the measurement_lookup values
     AND m.measurement_date >= cd.index_date -- Ensures a cognitive assessment occurs after cohort entry
 ),
  

--- a/SQL/Predictors/Demographic_Predictors.sql
+++ b/SQL/Predictors/Demographic_Predictors.sql
@@ -17,7 +17,8 @@ INNER JOIN demographic_index i ON p.person_id = i.person_id
 LEFT JOIN concept g ON p.gender_concept_id = g.concept_id
 LEFT JOIN concept r ON p.race_concept_id = r.concept_id
 LEFT JOIN concept e ON p.ethnicity_concept_id = e.concept_id
-WHERE 
-    LOWER(g.concept_name) NOT LIKE '%no matching concept%' AND
-    LOWER(r.concept_name) NOT LIKE '%no matching concept%' AND
-    LOWER(e.concept_name) NOT LIKE '%no matching concept%';
+---We should consider the values that are no matching concept
+-- WHERE 
+--     LOWER(g.concept_name) NOT LIKE '%no matching concept%' AND
+--     LOWER(r.concept_name) NOT LIKE '%no matching concept%' AND
+--     LOWER(e.concept_name) NOT LIKE '%no matching concept%';


### PR DESCRIPTION
In this PR we are updating the SQL query prototype to bump cohort size to 29k. This was done by:
* Considering also drug generic names (ingredients)
* Changing the column that joins measurement with measurement_lookup
* Removing the statement that excludes measurements with values_as_number = NULL. The code should be able to calculate this value from the measurement_lookup table

In addition, I removed the statements in the demographic_predictors.sql file that excluded patients with no matching concept. This is valuable information that should not be removed